### PR TITLE
Improve `flake.nix`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1685518550,
+        "narHash": "sha256-o2d0KcvaXzTrPRIo0kOLV0/QXHhDQ5DTi+OxcjO8xqY=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "a1720a10a6cfe8234c0e93907ffe81be440f4cef",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1686277352,
+        "narHash": "sha256-quryYLnntwZZrwJ4Vsx24hiCkwiYZAEttiOu983akGg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "a9fa8f8450a2ae296f152a9b3d52df68d24b7cfc",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,7 +1,36 @@
 {
   description = "Downloads and provides debug symbols and source code for nix derivations to gdb and other debuginfod-capable debuggers as needed.";
 
-  outputs = { ... }: {
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = {
+    self,
+    nixpkgs,
+    flake-utils,
+    ...
+  }:
+  let
+    packagesWith = pkgs: {
+      nixseparatedebuginfod = pkgs.callPackage ./nixseparatedebuginfod.nix {};
+    };
+  in
+  flake-utils.lib.eachDefaultSystem (system:
+    let
+      pkgs = import nixpkgs {
+        inherit system;
+        overlays = [self.overlays.default];
+      };
+    in rec {
+      packages = packagesWith pkgs // {
+        default = packages.nixseparatedebuginfod;
+      };
+      devShells.default = pkgs.callPackage ./shell.nix {};
+    }
+  ) // {
     nixosModules.default = import ./module.nix;
+    overlays.default = final: prev: packagesWith final;
   };
 }

--- a/shell.nix
+++ b/shell.nix
@@ -2,7 +2,8 @@
 #
 # SPDX-License-Identifier: CC0-1.0
 
-with import <nixpkgs> {};
+{ pkgs ? import <nixpkgs> {} }:
+with pkgs;
 mkShell {
   nativeBuildInputs = [
     cargo
@@ -11,12 +12,12 @@ mkShell {
     rust-analyzer
     sqlite
     openssl
-    (gdb.override { enableDebuginfod = true; })
     pkg-config
     reuse
     cargo-license
     cargo-outdated
-  ];
+  ]
+  ++ lib.optionals (!gdb.meta.unsupported) [gdb];
   buildInputs = [ libarchive ];
   RUST_BACKTRACE="full";
 }


### PR DESCRIPTION
I added some more outputs to the flake, because I'm running Nix using flakes on non NixOS.

`overlays` is based on `overlay.nix` to deduplicate some code and allows me to import it into my flakes.
`packages` allows me to invoke `nixseparatedebuginfod` with `nix run`.
`devShells` is based on the `shell.nix` which I converted to use the `overlay.nix` and allows me to use `nix develop`.

I hope these changes are welcome. I tried to add as few lines as possible.