### PR TITLE
Don't emit timestamps in log messages

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -62,7 +62,7 @@ async fn main() -> anyhow::Result<ExitCode> {
         )
     }
     let args = Options::parse();
-    tracing_subscriber::fmt::init();
+    tracing_subscriber::fmt().without_time().init();
 
     // check that nix-store is present
     match store::detect_nix() {


### PR DESCRIPTION
These are already provided by the systemd journal, which results in duplicate timestamps unless disabled.